### PR TITLE
Fix: CodeQL bad html with regex to beautiful soup

### DIFF
--- a/app/rules/security_rules.py
+++ b/app/rules/security_rules.py
@@ -1,29 +1,27 @@
 from typing import Any, Dict
 from app.rules.base import BaseRule
 from app.schemas.report import RuleResultSchema
-import re
+from bs4 import BeautifulSoup
 
 
 class NoScriptInjectionRule(BaseRule):
     name = "no_script_injection"
-    SCRIPT_PATTERN = re.compile(r"<script.*?>", re.IGNORECASE)
 
     def evaluate(self, payload: Dict[str, Any]) -> RuleResultSchema:
         found = False
 
         def scan(obj: Any):
             nonlocal found
-
             if isinstance(obj, dict):
                 for value in obj.values():
                     scan(value)
-
             elif isinstance(obj, list):
                 for item in obj:
                     scan(item)
-
             elif isinstance(obj, str):
-                if self.SCRIPT_PATTERN.search(obj):
+                # Parse HTML safely
+                soup = BeautifulSoup(obj, "html.parser")
+                if soup.find("script"):
                     found = True
 
         scan(payload)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ anyio==4.12.1
 astroid==4.0.4
 Authlib==1.6.9
 bandit==1.9.4
+beautifulsoup4>=4.12.2
 black==26.1.0
 certifi==2026.2.25
 cffi==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.12.1
+beautifulsoup4>=4.12.2
 certifi==2026.2.25
 click==8.3.1
 dnspython==2.8.0


### PR DESCRIPTION
Replaces the regex-based detection in NoScriptInjectionRule with a better scanner using BeautifulSoup, ensuring that all <script> tags—including malformed ones like <script foo="bar">—are correctly detected and blocked. This prevents script injection attacks that bypass the previous regex.